### PR TITLE
Add optional UUID parameter to GetSkin and GetCloakTexture methods

### DIFF
--- a/src/Gml.Web.Skin.Service/Core/Extensions/Application/ApplicationExtensions.cs
+++ b/src/Gml.Web.Skin.Service/Core/Extensions/Application/ApplicationExtensions.cs
@@ -46,15 +46,15 @@ public static class ApplicationExtensions
         app.MapGet("/{userName}", TextureRequests.GetUserTexture);
 
         app.MapPost("/skin/{userName}", TextureRequests.LoadSkin);
-        app.MapGet("/skin/{userName}", TextureRequests.GetSkin);
+        app.MapGet("/skin/{userName}/{uuid?}", TextureRequests.GetSkin);
         app.MapGet("/skin/{userName}/head/{size}", TextureRequests.GetSkinHead);
         app.MapGet("/skin/{userName}/front/{size}", TextureRequests.GetSkinFront);
         app.MapGet("/skin/{userName}/back/{size}", TextureRequests.GetSkinBack);
         app.MapGet("/skin/{userName}/full-back/{size}", TextureRequests.GetSkinAndCloakBack);
 
+        app.MapGet("/cloak/{userName}/{uuid?}", TextureRequests.GetCloakTexture);
         app.MapPost("/cloak/{userName}", TextureRequests.LoadCloak);
-        app.MapGet("/cloak/{userName}", TextureRequests.GetCloakTexture);
-        app.MapGet("/cloak/{userName}/{size}", TextureRequests.GetCloak);
+        app.MapGet("/cloak/{userName}/front/{size}", TextureRequests.GetCloak);
 
         app.MapGet("/refresh/{userName}", TextureRequests.RefreshCache);
 

--- a/src/Gml.Web.Skin.Service/Core/Requests/TextureRequests.cs
+++ b/src/Gml.Web.Skin.Service/Core/Requests/TextureRequests.cs
@@ -41,7 +41,7 @@ internal abstract class TextureRequests
         return Results.Ok(mapper.Map<UserTextureReadDto>(texture));
     }
 
-    internal static Task<IResult> GetSkin(HttpRequest request, string userName)
+    internal static Task<IResult> GetSkin(HttpRequest request, string userName, string? uuid)
     {
         var user = SkinHelper.Create($"http://{request.Host.Value}", userName);
 
@@ -83,7 +83,7 @@ internal abstract class TextureRequests
         return Task.FromResult(Results.File(image, "image/png"));
     }
 
-    internal static Task<IResult> GetCloakTexture(HttpRequest request, string userName)
+    internal static Task<IResult> GetCloakTexture(HttpRequest request, string userName, string uuid)
     {
         var user = SkinHelper.Create($"http://{request.Host.Value}", userName);
 


### PR DESCRIPTION
The GetSkin and GetCloakTexture methods in the TextureRequests class have been updated to include an optional UUID parameter. The ApplicationExtensions class was also modified to accomodate these changes, updating the mapping of GetSkin and GetCloakTexture to include the optional UUID parameter.