### PR TITLE
Remove scheduled Docker publish trigger

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,8 +6,6 @@ name: Docker
 # documentation.
 
 on:
-  schedule:
-    - cron: '18 0 * * *'
   push:
     branches: [ "master" ]
     # Publish semver tags as releases.


### PR DESCRIPTION
This commit removes the scheduled cron job that triggered Docker publishing every day at 00:18. Now, Docker publishing will only occur when there is a push to the master branch or when semver tags are published as releases.