### PR TITLE
Update skin and cloak URLs, modify username processing

### DIFF
--- a/src/Gml.Web.Skin.Service/Core/Extensions/Application/ApplicationExtensions.cs
+++ b/src/Gml.Web.Skin.Service/Core/Extensions/Application/ApplicationExtensions.cs
@@ -64,7 +64,7 @@ public static class ApplicationExtensions
         app.MapGet("/skin/{userName}/back/{size}", TextureRequests.GetSkinBack);
         app.MapGet("/skin/{userName}/full-back/{size}", TextureRequests.GetSkinAndCloakBack);
 
-        app.MapGet("/cloak/{userName}/{uuid?}", TextureRequests.GetCloakTexture);
+        app.MapGet("/cloak/{userName}", TextureRequests.GetCloakTexture);
         app.MapPost("/cloak/{userName}", TextureRequests.LoadCloak).DisableAntiforgery();;
         app.MapGet("/cloak/{userName}/front/{size}", TextureRequests.GetCloak);
 

--- a/src/Gml.Web.Skin.Service/Core/Requests/TextureRequests.cs
+++ b/src/Gml.Web.Skin.Service/Core/Requests/TextureRequests.cs
@@ -43,7 +43,7 @@ internal abstract class TextureRequests
 
     internal static Task<IResult> GetSkin(HttpRequest request, string userName, string? uuid)
     {
-        var user = SkinHelper.Create($"http://{request.Host.Value}", userName);
+        var user = SkinHelper.Create($"http://{request.Host.Value}", userName.Substring(2, userName.Length - 2));
 
         return Task.FromResult(Results.File(user.SkinFullPath, "image/png"));
     }
@@ -83,9 +83,9 @@ internal abstract class TextureRequests
         return Task.FromResult(Results.File(image, "image/png"));
     }
 
-    internal static Task<IResult> GetCloakTexture(HttpRequest request, string userName, string uuid)
+    internal static Task<IResult> GetCloakTexture(HttpRequest request, string userName)
     {
-        var user = SkinHelper.Create($"http://{request.Host.Value}", userName);
+        var user = SkinHelper.Create($"http://{request.Host.Value}", userName.Substring(2, userName.Length - 2));
 
         if (!user.HasCloak) return Task.FromResult(Results.NotFound("Cloak not exists"));
 

--- a/src/Gml.Web.Skin.Service/SkinHelper.cs
+++ b/src/Gml.Web.Skin.Service/SkinHelper.cs
@@ -29,14 +29,14 @@ public abstract class SkinHelper
             UserName = userName,
             HasSkin = !skinPath.EndsWith(DefaultSkinName),
             HasCloak = !string.IsNullOrEmpty(cloakPath),
-            SkinUrl = $"{requestPathBase}/skin/{userName}",
+            SkinUrl = $"{requestPathBase}/skin/s-{userName}",
             SkinFullPath = skinPath.EndsWith(DefaultSkinName)
                 ? Path.Combine(Environment.CurrentDirectory, SkinTextureDirectory, "default.png")
                 : Path.Combine(Environment.CurrentDirectory, SkinTextureDirectory, $"{userName}.png"),
             CloakFullPath = string.IsNullOrEmpty(cloakPath)
                 ? string.Empty
                 : Path.Combine(Environment.CurrentDirectory, CloakTextureDirectory, $"{userName}.png"),
-            ClockUrl = $"{requestPathBase}/cloak/{userName}",
+            ClockUrl = $"{requestPathBase}/cloak/c-{userName}",
             Texture = new SkinPartialsDto
             {
                 Head = $"{requestPathBase}/skin/{userName}/head/128",


### PR DESCRIPTION
Changed URLs for skin and cloak endpoints to include prefixes. Additionally, updated username handling to strip the first two characters when creating a user in SkinHelper. These adjustments were made to standardize and optimize URL routing and user data processing.